### PR TITLE
Add missing zero function for Scalar

### DIFF
--- a/solana-ristretto/src/scalar.rs
+++ b/solana-ristretto/src/scalar.rs
@@ -40,4 +40,8 @@ impl Scalar {
         let result = left * right;
         Ok(Self(result.into()))
     }
+
+    pub fn zero() -> Self {
+        Scalar(PodScalar([0u8; 32]))
+    }
 }


### PR DESCRIPTION
This PR adds the Scalar::zero() function in solana-ristretto for non-solana targets. 